### PR TITLE
Upgrades for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            python-version: "3.6"
+          - os: ubuntu-22.04
+            python-version: "3.12"
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - run: pip install --editable .[dev]
+    - run: python csb/build.py -o .

--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,9 @@ package consists of a few major components:
 
 Installation 
 ------------
-CSB is being developed on Linux with Python 2.7 and 3.6. However, compatibility
+CSB is being developed on Linux. However, compatibility
 is a design goal and the package works on any platform, on any modern Python
-interpreter since version 2.6 (that includes python 3 support out of
-the box). If you find any issues on a platform/interpreter different from
+interpreter. If you find any issues on a platform/interpreter different from
 our development environment, please let us know.
 
 CSB and all of its dependencies can be installed with pip::

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,6 @@ CSB is open source and distributed under OSI-approved MIT license.
     
 ------------
 
-.. image:: https://travis-ci.org/csb-toolbox/CSB.svg?branch=master
-   :target: https://travis-ci.org/csb-toolbox
+.. image:: https://github.com/csb-toolbox/CSB/workflows/CI/badge.svg
+   :target: https://github.com/csb-toolbox/CSB/actions
 

--- a/csb/bio/io/hhpred.py
+++ b/csb/bio/io/hhpred.py
@@ -207,7 +207,7 @@ class HHProfileParser(object):
                 hmm.family = line[6:].strip()
 
             elif line.startswith('LENG '):
-                m = re.search('(\d+)\D+(\d+)', line).groups()
+                m = re.search(r'(\d+)\D+(\d+)', line).groups()
                 m = tuple(map(int, m))
                 hmm.length = ProfileLength(m[0], m[1])
 
@@ -257,7 +257,7 @@ class HHProfileParser(object):
             if header_token in ['>ss_dssp', '>sa_dssp', '>ss_pred', '>ss_conf', '>Consens']:
 
                 lines = entry.strip().splitlines()
-                seq = re.sub('\s+', '', ''.join(lines[1:]))
+                seq = re.sub(r'\s+', '', ''.join(lines[1:]))
 
                 if header_token == '>ss_dssp':
                     hmm.dssp = structure.SecondaryStructure(seq)
@@ -304,7 +304,7 @@ class HHProfileParser(object):
         start_probs = None
 
         lines = iter(self._profile)
-        pattern = re.compile('^[A-Z\-]\s[0-9]+\s+')
+        pattern = re.compile(r'^[A-Z\-]\s[0-9]+\s+')
 
         if units == ScoreUnits.LogScales:
 

--- a/csb/bio/io/procheck.py
+++ b/csb/bio/io/procheck.py
@@ -28,16 +28,16 @@ class ProcheckParser():
         f_handler = open(os.path.expanduser(fn))
         text = f_handler.read()
         
-        input_file_name = re.compile('>>>-----.*?\n.*?\n\s*\|\s*(\S+)\s+')
-        residues = re.compile('(\d+)\s*residues\s\|')
-        ramachandran_plot = re.compile('Ramachandran\splot:\s*(\d+\.\d+)' + 
-                                      '%\s*core\s*(\d+\.\d+)%\s*allow\s*(\d+\.\d+)' + 
-                                      '%\s*gener\s*(\d+\.\d+)%\s*disall')
-        labelled_all = re.compile('Ramachandrans:\s*(\d+)\s*.*?out\sof\s*(\d+)')
-        labelled_chi = re.compile('Chi1-chi2\splots:\s*(\d+)\s*.*?out\sof\s*(\d+)')
-        bad_contacts = re.compile('Bad\scontacts:\s*(\d+)')
-        g_factors = re.compile('G-factors\s*Dihedrals:\s*([0-9-+.]+)' + 
-                              '\s*Covalent:\s*([0-9-+.]+)\s*Overall:\s*([0-9-+.]+)')
+        input_file_name = re.compile('>>>-----.*?\n.*?\n' r'\s*\|\s*(\S+)\s+')
+        residues = re.compile(r'(\d+)\s*residues\s\|')
+        ramachandran_plot = re.compile(r'Ramachandran\splot:\s*(\d+\.\d+)' + 
+                                      r'%\s*core\s*(\d+\.\d+)%\s*allow\s*(\d+\.\d+)' + 
+                                      r'%\s*gener\s*(\d+\.\d+)%\s*disall')
+        labelled_all = re.compile(r'Ramachandrans:\s*(\d+)\s*.*?out\sof\s*(\d+)')
+        labelled_chi = re.compile(r'Chi1-chi2\splots:\s*(\d+)\s*.*?out\sof\s*(\d+)')
+        bad_contacts = re.compile(r'Bad\scontacts:\s*(\d+)')
+        g_factors = re.compile(r'G-factors\s*Dihedrals:\s*([0-9-+.]+)' + 
+                              r'\s*Covalent:\s*([0-9-+.]+)\s*Overall:\s*([0-9-+.]+)')
 
         info['input_file'] = input_file_name.search(text).groups()[0]
         info['#residues'] = int(residues.search(text).groups()[0])

--- a/csb/bio/io/whatif.py
+++ b/csb/bio/io/whatif.py
@@ -29,11 +29,11 @@ class WhatCheckParser(object):
         text = f_handler.read()
 
         info = dict()
-        re_ramachandran = re.compile('Ramachandran\s*Z-score\s*:\s*([0-9.Ee-]+)')
-        re_1st = re.compile('1st\s*generation\s*packing\s*quality\s*:\s*([0-9.Ee-]+)')
-        re_2nd = re.compile('2nd\s*generation\s*packing\s*quality\s*:\s*([0-9.Ee-]+)')
-        re_backbone = re.compile('Backbone\s*conformation\s*Z-score\s*:\s*([0-9.Ee-]+)')
-        re_rotamer = re.compile('chi-1\S*chi-2\s*rotamer\s*normality\s*:\s*([0-9.Ee-]+)')
+        re_ramachandran = re.compile(r'Ramachandran\s*Z-score\s*:\s*([0-9.Ee-]+)')
+        re_1st = re.compile(r'1st\s*generation\s*packing\s*quality\s*:\s*([0-9.Ee-]+)')
+        re_2nd = re.compile(r'2nd\s*generation\s*packing\s*quality\s*:\s*([0-9.Ee-]+)')
+        re_backbone = re.compile(r'Backbone\s*conformation\s*Z-score\s*:\s*([0-9.Ee-]+)')
+        re_rotamer = re.compile(r'chi-1\S*chi-2\s*rotamer\s*normality\s*:\s*([0-9.Ee-]+)')
         
 
         info['rama_z_score'] = float(re_ramachandran.search(text).groups(0)[0])

--- a/csb/bio/io/wwpdb.py
+++ b/csb/bio/io/wwpdb.py
@@ -1219,7 +1219,7 @@ class RegularStructureParser(AbstractStructureParser):
         @return: resolution
         @rtype: float or None
         """
-        res = re.search("(\d+(?:\.\d+)?)\s+ANGSTROM", line)
+        res = re.search(r"(\d+(?:\.\d+)?)\s+ANGSTROM", line)
         
         if res and res.groups():
             return float(res.group(1))

--- a/csb/bio/sequence/__init__.py
+++ b/csb/bio/sequence/__init__.py
@@ -563,7 +563,7 @@ class Sequence(AbstractSequence):
     
     def _append(self, string):
         # this seems to be the fastest method for sanitization and storage        
-        self._residues += re.sub('([^\w\-\.])+', '', string)
+        self._residues += re.sub(r'([^\w\-\.])+', '', string)
         
     def _add(self, char):
         self._append(char)

--- a/csb/bio/structure/__init__.py
+++ b/csb/bio/structure/__init__.py
@@ -2126,9 +2126,9 @@ class SecondaryStructure(csb.core.CollectionContainer):
         if not isinstance(string, csb.core.string):
             raise TypeError(string)
                 
-        string = ''.join(re.split('\s+', string))
+        string = ''.join(re.split(r'\s+', string))
         if conf_string is not None:
-            conf_string = ''.join(re.split('\s+', conf_string))
+            conf_string = ''.join(re.split(r'\s+', conf_string))
             if not len(string) == len(conf_string):
                 raise ValueError('The confidence string has unexpected length.')
         motifs = [ ]

--- a/csb/statistics/__init__.py
+++ b/csb/statistics/__init__.py
@@ -338,7 +338,7 @@ def running_average(x, w, axis=None):
     return array([mean(x[i:i + w], axis) for i in range(len(x) - w)])
 
 def weighted_median(x, w):
-    """
+    r"""
     Calculates the weighted median, that is the minimizer of
     argmin {\sum w_i |x_i - \mu|}
 

--- a/csb/test/__init__.py
+++ b/csb/test/__init__.py
@@ -159,7 +159,7 @@ decorators you would need in order to write tests for CSB.
 """
 import os
 import sys
-import imp
+import importlib
 import types
 import time
 import tempfile
@@ -443,7 +443,7 @@ class Case(unittest.TestCase):
                 
         return runner.run(suite)            
 
-class InvalidNamespaceError(NameError, ImportError):
+class InvalidNamespaceError(ImportError):
     pass
     
 class AbstractTestBuilder(object):
@@ -567,7 +567,11 @@ class AbstractTestBuilder(object):
         name = os.path.splitext(os.path.abspath(path))[0]
         name = name.replace('.', '-').rstrip('__init__').strip(os.path.sep)
         
-        return imp.load_source(name, path)        
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        return module
     
     def _recurse(self, obj):
         """

--- a/csb/test/cases/core/__init__.py
+++ b/csb/test/cases/core/__init__.py
@@ -18,7 +18,7 @@ class TestDeepCopy(test.Case):
         copy = utils.deepcopy(obj, recursion=(rec + 1))
         
         self.assertEqual(obj, copy)
-        self.assertNotEquals(id(obj), id(copy))
+        self.assertNotEqual(id(obj), id(copy))
 
 @test.unit
 class TestIterable(test.Case):
@@ -70,7 +70,8 @@ class TestEnum(test.Case):
     def testComparison(self):
         self.assertEqual(self.enum.A, 0)
         self.assertEqual(self.enum.C, 66)
-        self.assertFalse(self.enum.C is 66)
+        int_66 = 66
+        self.assertFalse(self.enum.C is int_66)
         self.assertFalse(isinstance(self.enum.A, int))
         
     def testStr(self):

--- a/csb/test/cases/io/__init__.py
+++ b/csb/test/cases/io/__init__.py
@@ -479,7 +479,7 @@ class TestDumpLoad(test.Case):
                         "Although that way may not be" + \
                         "obvious at first" + \
                         "unless you're Dutch.",
-                        "([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])"]
+                        r"([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])"]
 
         # Completly connnected graph
         

--- a/csb/test/cases/statistics/samplers/__init__.py
+++ b/csb/test/cases/statistics/samplers/__init__.py
@@ -801,6 +801,12 @@ class HState(State):
         return s
 
 
+def _arrays_equal(a1, a2) -> bool:
+    if a1.shape != a2.shape:
+        return False
+    return (a1 == a2).all()
+
+
 @test.functional
 class TestReplicaHistory(test.Case):
 
@@ -863,7 +869,7 @@ class TestReplicaHistory(test.Case):
         ok = []
         for i in range(len(samples[0])):
             trajs2 = rh.calculate_projected_trajectories(i)
-            ok.append(True in [np.all(np.array(t1) == np.array(t2)) for t1 in trajs1
+            ok.append(True in [_arrays_equal(np.array(t1), np.array(t2)) for t1 in trajs1
                                for t2 in trajs2])
             
         return np.all(ok)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ DESCRIPTION = __doc__
 LICENSE = 'MIT'
 
 REQUIREMENTS = open("requirements.txt", encoding="utf-8").readlines()
-DEV_REQUIREMENTS = []
+DEV_REQUIREMENTS = ["setuptools"]
 
 v = {}
 exec(open(ROOT + "/__init__.py", encoding="utf-8").read(), v)

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,6 @@ LICENSE = 'MIT'
 REQUIREMENTS = open("requirements.txt", encoding="utf-8").readlines()
 DEV_REQUIREMENTS = []
 
-if sys.version_info[0] == 2:
-    DEV_REQUIREMENTS.append("epydoc")
-
 v = {}
 exec(open(ROOT + "/__init__.py", encoding="utf-8").read(), v)
 VERSION = v["Version"]()
@@ -69,13 +66,13 @@ def build():
             'License :: OSI Approved :: MIT License',
             'Operating System :: OS Independent',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.1',
-            'Programming Language :: Python :: 3.2',
-            'Programming Language :: Python :: 3.3',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.12',
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: Bio-Informatics',
             'Topic :: Scientific/Engineering :: Mathematics',


### PR DESCRIPTION
- Replace `imp.load_source`
- Fix invalid escape sequences (W605)
- Fix `TestReplicaHistory` test
- Require Python 3.6+